### PR TITLE
Add comprehensive Markdown documentation for core Fortran files.

### DIFF
--- a/TransOpt_1.1.md
+++ b/TransOpt_1.1.md
@@ -1,0 +1,85 @@
+# TransOpt 1.1 Documentation
+
+## Overview
+
+TransOpt 1.1 is a Fortran program designed to calculate electronic transport properties of materials. It utilizes Boltzmann transport theory, typically taking pre-calculated electronic band structures and group velocities (often from DFT software like VASP) as input. The program then computes various transport coefficients such as electrical conductivity, Seebeck coefficient, and electronic thermal conductivity.
+
+## Key Components
+
+The program consists of a main program (`TransOpt`) and several modules and subroutines:
+
+*   **Program `TransOpt`**: This is the main driver of the code. It handles reading input files, orchestrating the calculation steps by calling various subroutines, and writing the final transport properties to output files.
+*   **Module `params`**: Defines fundamental physical constants (e.g., Boltzmann constant, Planck constant, electron charge, electron mass) and numerical precision parameters (e.g., `dp` for double precision).
+*   **Module `Fermifunction`**:
+    *   `DFERMI(E, EF, T, spi)`: Calculates the derivative of the Fermi-Dirac distribution function with respect to energy.
+    *   `FERMI(E, EF, T, spi)`: Calculates the Fermi-Dirac distribution function.
+*   **Module `variable`**: Declares global variables related to k-points (coordinates `irkpt`, `kpt`; weights `irkwpt`), band energies (`irbandenergy`, `bandenergy`), crystal structure information (e.g., lattice vectors `vec`, cell volume `volume`, scaling factor `scales`), and run control parameters (e.g., number of k-points `nirk`, `nk`; number of bands `nband`; number of spins `nspin`).
+*   **Module `ef`**:
+    *   `getef(ferminorigin, fermaxorigin)`: A subroutine to determine the Fermi level (`efermi`) iteratively based on the total number of electrons (`totale`) and the density of states.
+*   **Module `variables`**: Declares a wide range of global variables essential for the transport calculations. These include:
+    *   Electronic structure arrays: group velocities (`irvk`, `vk`), relaxation times (`irtau`, `alltau`).
+    *   Transport coefficients: conductivity (`cond`, `cond_tau`), Seebeck coefficient (`seebeck`, `seebeck_tau`), electronic thermal conductivity (`ke`, `ke_tau`), and their inverses or temporary calculation arrays.
+    *   Input parameters: energy range for calculations (`estart`, `de`, `nemu`), temperature (`T`), scissor operation parameters (`nCBB`, `sis`), deformation potential (`Edef`), elastic constant (`elastic`), Gaussian smearing width (`sigma`).
+    *   Control flags: `CRTAonly` (Constant Relaxation Time Approximation only), `carrier` (whether to calculate carrier concentration dependent properties), `readTAU` (flag to read pre-calculated TAU file).
+*   **Subroutine `getTAU()`**: Calculates the momentum relaxation times (`irtau`). In version 1.1, this is primarily based on deformation potential (DP) theory for electron-acoustic phonon scattering. It considers parameters like deformation potential (`Edef`), elastic constant (`elastic`), and temperature (`T`).
+*   **Subroutine `getdos()`**: Calculates the Density of States (DOS) and related energy-integrated quantities based on the band energies and Fermi level.
+*   **Subroutine `gettrans()`**: This is a core calculation routine. It computes the tensors for electrical conductivity (`cond`, `cond_tau`), the Mueller matrix components (`mu`, `mu_tau`), and the kappa tensors (`kappa`, `kappa_tau`) by integrating products of group velocities, relaxation times, and Fermi-Dirac distribution derivatives over the Brillouin zone. It then derives the Seebeck coefficient and electronic thermal conductivity from these tensors.
+*   **Subroutine `output()`**: Writes the calculated transport properties (conductivity, Seebeck coefficient, power factor, electronic thermal conductivity, Lorenz number) as a function of energy/chemical potential (`emu`) to various output files: `CRTA-trace-e.txt` (trace of tensors under CRTA), `CRTA-tensor-e.txt` (full tensors under CRTA), and if RTA is performed (`.not. CRTAonly`), `RTA-trace-e.txt` and `RTA-tensor-e.txt`.
+*   **Subroutine `vkrotate(finalvk, originalvk, sym, vec)`**: Rotates a group velocity vector (`originalvk`) according to a given symmetry operation matrix (`sym`) and lattice vectors (`vec`) to obtain the rotated vector (`finalvk`).
+*   **Subroutine `inverse(a, b)`**: Calculates the inverse (`b`) of a 3x3 matrix (`a`).
+*   **Subroutine `matmulonethree(a, b, c)`**: Performs a multiplication of a 1x3 vector (`a`) with a 3x3 matrix (`b`) resulting in a 1x3 vector (`c`).
+*   **Subroutine `matmulthreethree(a, b, c)`**: Performs a multiplication of two 3x3 matrices (`a` and `b`) resulting in a 3x3 matrix (`c`).
+
+## Important Variables/Constants
+
+Key input parameters that control the behavior of TransOpt 1.1 are typically read from `finale.input` and `control.in`:
+
+*   **From `finale.input`**:
+    *   `efermi`: Initial Fermi level (eV).
+    *   `estart`: Starting energy relative to `efermi` for transport calculations (eV).
+    *   `de`: Energy step for transport calculations (eV).
+    *   `nemu`: Number of energy points to calculate.
+    *   `T`: Temperature (K).
+    *   `nCBB(:)`: Number of conduction/valence bands for scissor operation (for each spin).
+    *   `sis(:)`: Scissor energy shift (eV) (for each spin).
+    *   `carriertotale`: Target total carrier concentration if `carrier` flag is true.
+    *   `Edef(:)`: Deformation potential (eV) (for each spin).
+    *   `elastic`: Elastic constant (GPa).
+    *   `sigma`: Gaussian smearing width for energy (eV).
+*   **From `control.in`**:
+    *   `ifderivation`: Logical flag, `.TRUE.` if using derivation method for group velocities (requires `GVEC` and `OUTCAR`), `.FALSE.` for momentum matrix method (requires `GROUPVEC`).
+    *   `dimens(:)`: Logical array (3 elements) specifying which dimensions (x, y, z) to consider for transport.
+    *   `ifprint`: Logical flag, `.TRUE.` to print detailed intermediate outputs like `EIGENVAL_full`, `klist`, `GROUPVEC_full`.
+
+## Usage Examples
+
+To run TransOpt 1.1, the following input files are generally required in the working directory:
+
+*   **For momentum matrix method (default if `ifderivation` is `.FALSE.` or `control.in` is absent):**
+    *   `GROUPVEC`: Contains group velocities.
+    *   `EIGENVAL`: Eigenvalues from VASP.
+    *   `POSCAR`: Crystal structure.
+    *   `SYMMETRY`: Symmetry operations.
+    *   `finale.input`: Main calculation parameters.
+    *   `control.in` (optional): Controls derivation method, dimensions, and printing.
+*   **For derivation method (`ifderivation` is `.TRUE.` in `control.in`):**
+    *   `GVEC`: Group velocities (alternative to `GROUPVEC`, possibly from `derivation.f90`).
+    *   `EIGENVAL`
+    *   `POSCAR`
+    *   `SYMMETRY`
+    *   `finale.input`
+    *   `control.in`
+    *   `OUTCAR`: VASP output file (used to check for SOC if `ifderivation` is true).
+
+**Expected output files:**
+*   `CRTA-trace-e.txt`: Trace of transport tensors vs. energy (CRTA).
+*   `CRTA-tensor-e.txt`: Full transport tensors vs. energy (CRTA).
+*   `RTA-trace-e.txt`: Trace of transport tensors vs. energy (RTA, if not `CRTAonly`).
+*   `RTA-tensor-e.txt`: Full transport tensors vs. energy (RTA, if not `CRTAonly`).
+*   `TAU` (if generated): Calculated relaxation times.
+
+## Dependencies and Interactions
+
+*   **VASP**: TransOpt heavily relies on outputs from VASP (or compatible DFT codes) for `EIGENVAL`, `POSCAR`, `OUTCAR`, and often `GROUPVEC`.
+*   **Input Files**: The behavior is controlled by `finale.input` and `control.in`. The format and content of these files are critical.
+*   **`derivation.f90`**: The `GVEC` file, if used, can be generated by the `derivation.f90` program.

--- a/TransOpt_2.0.md
+++ b/TransOpt_2.0.md
@@ -1,0 +1,90 @@
+# TransOpt 2.0 Documentation
+
+## Overview
+
+TransOpt 2.0 is an updated version of the TransOpt Fortran program, designed for calculating electronic transport properties based on Boltzmann transport theory. It builds upon version 1.1 by incorporating more advanced scattering mechanisms, particularly ionized impurity scattering, and streamlining input file management. It continues to use pre-calculated electronic band structures and group velocities, typically from DFT software like VASP, as primary inputs.
+
+## Key Components
+
+The program structure is similar to version 1.1, with a main program (`TransOpt`) and several modules and subroutines. Key changes and additions in version 2.0 include:
+
+*   **Program `TransOpt`**: Main driver, similar to 1.1, but adapted for new input handling and scattering options.
+*   **Module `params`**: Defines physical constants and precision. Adds `epsilon_0` (vacuum permittivity).
+*   **Module `Fermifunction`**: Unchanged from 1.1.
+    *   `DFERMI(E, EF, T, spi)`
+    *   `FERMI(E, EF, T, spi)`
+*   **Module `variable`**: Declares global variables. Key changes:
+    *   `vecb(3,3)`: Reciprocal lattice vectors.
+    *   `scattering`: Integer flag to select scattering mechanisms.
+*   **Module `ef`**: Unchanged from 1.1.
+    *   `getef(ferminorigin, fermaxorigin)`
+*   **Module `variables`**: Declares global variables for electronic structure and transport. Key changes:
+    *   **Input Handling**: `control.in` is deprecated. Its functionality (ifderivation, dimens, ifprint) and new scattering control are managed via `TransOpt.input`.
+    *   **Scattering Parameters**: New variables for ionized impurity scattering: `epsilon_r` (relative dielectric constant), `nimpurity` (impurity concentration), `n0` (carrier concentration for screening), `zion` (charge state of impurity).
+    *   **Deformation Potential**: `Edef(:)` from version 1.1 is now split into `EdefVB(:)` (for valence bands) and `EdefCB(:)` (for conduction bands) for more specific treatment.
+    *   The `readTAU` flag and related variables (`sigma_origin`, `T_origin`, `elastic_origin`) are noted as discontinued/unnecessary in the comments, as `getTAU` now recalculates relaxation times based on the chosen `scattering` model.
+*   **Subroutine `getTAU()`**: Significantly updated to handle different scattering mechanisms:
+    *   If `scattering = 1` (acoustic phonon scattering): Calculates relaxation time based on deformation potential theory, similar to 1.1 but using `EdefVB` and `EdefCB`.
+    *   If `scattering = 2` (acoustic phonon + ionized impurity scattering): Calculates relaxation rates for both mechanisms and combines them using Matthiessen's rule. Ionized impurity scattering calculation involves parameters like `zion`, `nimpurity`, `n0`, `epsilon_r`, and screening length `LD`.
+    *   The calculation of relaxation times is now done on the full k-mesh (`alltau`) directly, rather than interpolating from irreducible k-mesh (`irtau`).
+*   **Subroutine `getdos()`**: Similar to 1.1, calculates DOS. If `scattering > 0`, it also calculates `dostau` using the new `alltau`.
+*   **Subroutine `gettrans()`**: Similar to 1.1, calculates transport coefficients. Uses `alltau` if `scattering > 0`.
+*   **Subroutine `output()`**: Similar to 1.1, writes calculated transport properties. Output format remains largely the same.
+*   **Subroutine `vkrotate(finalvk, originalvk, sym, vec)`**: Unchanged from 1.1.
+*   **Subroutine `inverse(a, b)`**: Unchanged from 1.1.
+*   **Subroutine `matmulonethree(a, b, c)`**: Unchanged from 1.1.
+*   **Subroutine `matmulthreethree(a, b, c)`**: Unchanged from 1.1.
+
+## Important Variables/Constants
+
+Key input parameters for TransOpt 2.0 are read from `TransOpt.input` (which replaces `finale.input` and `control.in`):
+
+*   **Line 1**: `ifderivation` (Logical: `.TRUE.` for derivation method, `.FALSE.` for momentum matrix).
+*   **Line 2**: `dimens(:)` (Logical array (3 elements): x, y, z dimensions for transport).
+*   **Line 3**: `ifprint` (Logical: `.TRUE.` for detailed printing).
+*   **Line 4**: `scattering` (Integer: `0` for CRTA only, `1` for acoustic phonon scattering (RTA), `2` for acoustic + ionized impurity scattering (RTA)).
+*   **Line 5 (general parameters)**:
+    *   `efermi`: Initial Fermi level (eV).
+    *   `estart`: Starting energy relative to `efermi` (eV).
+    *   `de`: Energy step (eV).
+    *   `nemu`: Number of energy points.
+    *   `T`: Temperature (K).
+    *   `nCBB(:)`: Number of conduction/valence bands for scissor operation (for each spin).
+    *   `sis(:)`: Scissor energy shift (eV) (for each spin).
+    *   `carriertotale`: Target total carrier concentration if `carrier` flag is true.
+*   **Line 6 (if `scattering > 0`)**:
+    *   `EdefVB(:)`: Deformation potential for valence bands (eV) (for each spin).
+    *   `EdefCB(:)`: Deformation potential for conduction bands (eV) (for each spin).
+    *   `elastic`: Elastic constant (GPa).
+    *   `sigma`: Gaussian smearing width for energy (eV).
+*   **Line 7 (if `scattering = 2`)**:
+    *   `zion`: Charge state of the impurity.
+    *   `nimpurity`: Impurity concentration (e.g., in 10^20 cm^-3).
+    *   `n0`: Carrier concentration for screening (e.g., in 10^20 cm^-3).
+    *   `epsilon_r`: Relative dielectric constant.
+
+## Usage Examples
+
+To run TransOpt 2.0, the following input files are generally required:
+
+*   `TransOpt.input`: Contains all control parameters and calculation settings.
+*   `EIGENVAL`: Eigenvalues from VASP.
+*   `POSCAR`: Crystal structure.
+*   `SYMMETRY`: Symmetry operations.
+*   `OUTCAR`: VASP output file (used to check for SOC if `ifderivation` is true, and potentially for other parameters like dielectric constant if not specified in input).
+*   **Either `GROUPVEC` or `GVEC`**:
+    *   `GROUPVEC`: Contains group velocities (if `ifderivation = .FALSE.`).
+    *   `GVEC`: Group velocities from derivation method (if `ifderivation = .TRUE.`).
+
+**Expected output files:**
+*   `CRTA-trace-e.txt`: Trace of transport tensors vs. energy (CRTA).
+*   `CRTA-tensor-e.txt`: Full transport tensors vs. energy (CRTA).
+*   `RTA-trace-e.txt`: Trace of transport tensors vs. energy (RTA, if `scattering > 0`).
+*   `RTA-tensor-e.txt`: Full transport tensors vs. energy (RTA, if `scattering > 0`).
+*   `TAU` (if `scattering > 0`): Calculated relaxation times on the full k-mesh.
+
+## Dependencies and Interactions
+
+*   **VASP**: Relies on VASP outputs for `EIGENVAL`, `POSCAR`, `OUTCAR`, and often `GROUPVEC`.
+*   **Input File**: The primary control is through `TransOpt.input`.
+*   **`derivation.f90`**: The `GVEC` file, if used, can be generated by the `derivation.f90` program.

--- a/TransOpt_omp_1.1.md
+++ b/TransOpt_omp_1.1.md
@@ -1,0 +1,42 @@
+# TransOpt OMP 1.1 Documentation
+
+## Overview
+
+TransOpt OMP 1.1 is the OpenMP-parallelized version of the `TransOpt_1.1.f90` program. It is designed to calculate electronic transport properties of materials using Boltzmann transport theory and can leverage multi-core processors to speed up computationally intensive parts of the calculation. Like its serial counterpart, it uses pre-calculated electronic band structures and group velocities as input.
+
+## Key Components
+
+The core logic, modules, and most subroutines in TransOpt OMP 1.1 are identical to those in `TransOpt_1.1.f90`. Please refer to the `TransOpt_1.1.md` documentation for a detailed description of:
+
+*   Program `TransOpt`
+*   Module `params`
+*   Module `Fermifunction`
+*   Module `variable`
+*   Module `ef`
+*   Module `variables`
+*   Subroutine `getdos`
+*   Subroutine `gettrans`
+*   Subroutine `output`
+*   Subroutine `vkrotate`
+*   Subroutine `inverse`
+*   Subroutines `matmulonethree`, `matmulthreethree`
+
+The primary difference lies in the **`getTAU` subroutine**:
+
+*   **Subroutine `getTAU()`**: This subroutine, which calculates momentum relaxation times, has been parallelized using OpenMP directives. Specifically, the loops involved in calculating the scattering rates (which sum over k-points and bands) are parallelized. This can significantly reduce the wall time for this part of the calculation on systems with multiple CPU cores. The underlying physics and calculation method for relaxation time (deformation potential theory) remain the same as in `TransOpt_1.1.f90`.
+
+## Important Variables/Constants
+
+The important variables, constants, and input parameters read from `finale.input` and `control.in` are identical to those used in `TransOpt_1.1.f90`. Please refer to the "Important Variables/Constants" section in `TransOpt_1.1.md`.
+
+## Usage Examples
+
+The required input files (`GROUPVEC`, `EIGENVAL`, `POSCAR`, `SYMMETRY`, `finale.input`, `control.in`, `GVEC`, `OUTCAR`) and the expected output files (`CRTA-trace-e.txt`, `CRTA-tensor-e.txt`, `RTA-trace-e.txt`, `RTA-tensor-e.txt`, `TAU`) are the same as for `TransOpt_1.1.f90`.
+
+Refer to the "Usage Examples" section in `TransOpt_1.1.md`.
+
+The main difference in usage is that the compiled `TransOpt_omp_1.1` executable can benefit from setting OpenMP environment variables (e.g., `OMP_NUM_THREADS`) to control the number of threads used for parallel regions.
+
+## Dependencies and Interactions
+
+The dependencies and interactions with VASP outputs and input files (`finale.input`, `control.in`) are the same as for `TransOpt_1.1.f90`. Please refer to the "Dependencies and Interactions" section in `TransOpt_1.1.md`. The program must be compiled with an OpenMP-enabled Fortran compiler for the parallelization to be active.

--- a/TransOpt_omp_2.0.md
+++ b/TransOpt_omp_2.0.md
@@ -1,0 +1,42 @@
+# TransOpt OMP 2.0 Documentation
+
+## Overview
+
+TransOpt OMP 2.0 is the OpenMP-parallelized version of the `TransOpt_2.0.f90` program. It is designed for calculating electronic transport properties and includes advanced scattering mechanisms like ionized impurity scattering, along with streamlined input file management via `TransOpt.input`. This version can utilize multi-core processors to accelerate computationally intensive sections, particularly the calculation of relaxation times.
+
+## Key Components
+
+The core logic, modules, and most subroutines in TransOpt OMP 2.0 are identical to those in `TransOpt_2.0.f90`. For a detailed description of the following components, please refer to the `TransOpt_2.0.md` documentation:
+
+*   Program `TransOpt`
+*   Module `params`
+*   Module `Fermifunction`
+*   Module `variable`
+*   Module `ef`
+*   Module `variables` (including parameters for new scattering mechanisms and updated input handling)
+*   Subroutine `getdos`
+*   Subroutine `gettrans`
+*   Subroutine `output`
+*   Subroutine `vkrotate`
+*   Subroutine `inverse`
+*   Subroutines `matmulonethree`, `matmulthreethree`
+
+The primary distinction of the OMP version is within the **`getTAU` subroutine**:
+
+*   **Subroutine `getTAU()`**: This subroutine, responsible for calculating momentum relaxation times considering different scattering mechanisms (acoustic phonon, ionized impurity), has been parallelized using OpenMP directives. The loops involved in summing contributions to scattering rates over k-points and bands are parallelized. This is particularly beneficial for the `scattering=2` option (acoustic + ionized impurity), which involves a double loop over the full k-mesh. The underlying physics and calculation methods for the scattering mechanisms remain the same as in `TransOpt_2.0.f90`.
+
+## Important Variables/Constants
+
+The important variables, constants, and the structure of the `TransOpt.input` file (which controls calculation parameters, including scattering options) are identical to those used in `TransOpt_2.0.f90`. Please refer to the "Important Variables/Constants" section in `TransOpt_2.0.md`.
+
+## Usage Examples
+
+The required input files (`TransOpt.input`, `EIGENVAL`, `POSCAR`, `SYMMETRY`, `OUTCAR`, `GROUPVEC`/`GVEC`) and the expected output files (`CRTA-trace-e.txt`, `CRTA-tensor-e.txt`, `RTA-trace-e.txt`, `RTA-tensor-e.txt`, `TAU`) are the same as for `TransOpt_2.0.f90`.
+
+Refer to the "Usage Examples" section in `TransOpt_2.0.md`.
+
+When using `TransOpt_omp_2.0`, performance can be enhanced by setting OpenMP environment variables (e.g., `OMP_NUM_THREADS`) to control the number of threads utilized during parallel execution.
+
+## Dependencies and Interactions
+
+The dependencies and interactions with VASP outputs and the `TransOpt.input` file are the same as for `TransOpt_2.0.f90`. Please refer to the "Dependencies and Interactions" section in `TransOpt_2.0.md`. For the parallelization to be effective, the program must be compiled with an OpenMP-enabled Fortran compiler.

--- a/derivation.md
+++ b/derivation.md
@@ -1,0 +1,70 @@
+# Derivation Program Documentation (`derivation.f90`)
+
+## Overview
+
+The Fortran program `derivation.f90` (containing a main program named `main`) is designed to calculate k-space derivatives of electronic band energies. These derivatives are used to determine group velocities and effective mass tensors. The outputs of this program, particularly the group velocities (`GVEC`), can serve as input for the main TransOpt transport calculation programs (e.g., `TransOpt_1.1.f90`, `TransOpt_2.0.f90`) when the `ifderivation` flag is enabled. Alternatively, the calculated properties can be used for direct analysis of band structure features.
+
+## Key Components
+
+The program consists of a main program (`main`) and several modules and subroutines:
+
+*   **Program `main`**:
+    *   Reads crystal structure information from `POSCAR`.
+    *   Reads symmetry operations from `SYMMETRY`.
+    *   Reads eigenvalues from `EIGENVAL`.
+    *   Reads the Fermi level from `OUTCAR`.
+    *   Performs k-point symmetrization to generate a full k-mesh.
+    *   Sorts the k-points using the `quick_sort` subroutine.
+    *   Calls the `derivation` subroutine to calculate first and second derivatives of energy with respect to k.
+    *   Writes the calculated group velocities to `GVEC`.
+    *   Writes the calculated effective mass tensors (inverse) to `EFMASS`.
+*   **Module `params`**: Defines fundamental physical constants (e.g., Boltzmann constant, Planck constant, electron charge, electron mass) and numerical precision parameters.
+*   **Module `variable`**: Declares global variables used within the program, such as temperature (`T`), Fermi energy (`efermi`), lattice vectors (`vec`), volume (`volume`), number of bands (`nbands`), and number of spins (`nspins`).
+*   **Recursive Subroutine `quick_sort(k, left, right, corresponding)`**:
+    *   Sorts an array of k-points (`k`) in three dimensions (primarily by z, then y, then x).
+    *   Keeps track of the original indices using the `corresponding` array. This is used to ensure that eigenvalues are correctly mapped after k-points are reordered.
+*   **Subroutine `derivation(Energy, x, y, z, lenth, rtvecb, corresponding, derva, dervb, dervc, dervx, dervy, dervz)`**:
+    *   Calculates the first derivatives of energy (`Energy`) with respect to k in fractional coordinates (`derva`, `dervb`, `dervc`) and Cartesian coordinates (`dervx`, `dervy`, `dervz`) using finite difference methods.
+    *   `x`, `y`, `z`: Number of k-points along each reciprocal lattice direction.
+    *   `lenth`: Step sizes for finite differences in fractional coordinates.
+    *   `rtvecb`: Transformation matrix from fractional to Cartesian coordinates for derivatives.
+    *   The effective mass tensor components are calculated by further calls to this subroutine, passing previously calculated first derivatives (velocities) as input to get second derivatives.
+*   **Subroutine `inverse(a)`**: Calculates the inverse of a 3x3 matrix `a` *in place*. Note: This is a different `inverse` subroutine than the one found in `TransOpt_X.X.f90` programs, as it takes only one matrix argument and modifies it directly.
+*   **Subroutine `error()`**: A simple subroutine to stop the program execution, typically called when a required file is not found.
+
+## Important Variables/Constants
+
+*   **Input Data**: The program relies heavily on the content and format of:
+    *   `POSCAR`: For lattice vectors and scale.
+    *   `SYMMETRY`: For symmetry operations to unfold the irreducible k-points.
+    *   `EIGENVAL`: For k-points in the irreducible Brillouin zone and their corresponding band energies.
+    *   `OUTCAR`: Specifically to read the Fermi energy (`E-fermi` line).
+*   **Internal Parameters**:
+    *   `nkpts`: Number of k-points read from `EIGENVAL`.
+    *   `nbands`: Number of bands read from `EIGENVAL`.
+    *   `nspins`: Number of spins read from `EIGENVAL`.
+    *   `x, y, z`: Dimensions of the generated full k-mesh.
+    *   `fullkptcal`: Array holding the full k-mesh coordinates.
+    *   `fulleigcal`: Array holding energies on the full k-mesh.
+    *   `corresponding`: Array mapping sorted k-points back to their original order/properties.
+
+## Usage Examples
+
+To run the `derivation.f90` program (after compiling it), the following input files must be present in the working directory:
+
+*   `EIGENVAL`: VASP output containing irreducible k-points and eigenvalues.
+*   `POSCAR`: VASP input file defining the crystal structure.
+*   `SYMMETRY`: VASP output containing symmetry operations.
+*   `OUTCAR`: VASP main output file (used for Fermi level).
+
+**Execution:**
+Running the compiled executable (e.g., `./derivation_program`) will produce:
+
+*   `GVEC`: Output file containing the calculated group velocities (dx, dy, dz components for each band and k-point) in units of m/s (after internal conversion from atomic units). The format includes k-point coordinates, band index, group velocity components, and magnitude.
+*   `EFMASS`: Output file containing the inverse effective mass tensor components (m_xx, m_xy, m_xz, etc.) for each band and k-point. The values are scaled by (a/2pi)^2, where 'a' is likely related to lattice dimensions.
+*   `klist_int` (intermediate): A list of k-points.
+
+## Dependencies and Interactions
+
+*   **VASP**: This program is highly dependent on VASP output files (`EIGENVAL`, `POSCAR`, `SYMMETRY`, `OUTCAR`).
+*   **TransOpt Programs**: The `GVEC` file generated by `derivation.f90` can be used as an input to `TransOpt_1.1.f90` or `TransOpt_2.0.f90` (and their OMP versions) if the `ifderivation` flag in the TransOpt input (`control.in` or `TransOpt.input`) is set to `.TRUE.`. This provides an alternative to using the `GROUPVEC` file (momentum matrix elements) directly from VASP.


### PR DESCRIPTION
This commit introduces separate .md files for:
- TransOpt_1.1.f90
- TransOpt_2.0.f90
- TransOpt_omp_1.1.f90
- TransOpt_omp_2.0.f90
- derivation.f90

Each documentation file includes:
- An overview of the program/file.
- Descriptions of key functions, modules, and subroutines.
- Information on important variables and input parameters.
- Usage examples, including required input and expected output files.
- Notes on dependencies and interactions with other system parts (e.g., VASP).

The documentation for OMP versions references the serial versions and specifically details the OpenMP parallelization.